### PR TITLE
Modify Dockerfile to compile app and create bare container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,21 @@
-FROM scratch
-MAINTAINER vishnuk@google.com
+# Container to build stress
+FROM golang:latest AS builder
 
-ADD stress /
+LABEL maintainer="vishnuk@google.com"
+
+WORKDIR /
+
+COPY main.go /.
+
+RUN GOBIN=/ go get
+
+RUN GOBIN=/ CGO_ENABLED=0 go build --ldflags '-extldflags "-static"' -o stress
+
+# Container to publish
+FROM scratch
+
+LABEL maintainer="vishnuk@google.com"
+
+COPY --from=builder  /stress /
 
 ENTRYPOINT ["/stress", "-logtostderr"]


### PR DESCRIPTION
Uses a temporary "builder" container based on golang:latest image to build binary, then 
creates a scratch (empty) container to hold the statically linked binary.